### PR TITLE
updates ApiClient.cs to use the upcoming school year profile

### DIFF
--- a/MDE-EdFiClientSDK/EdFi/Generate-SDK-From-Json.ps1
+++ b/MDE-EdFiClientSDK/EdFi/Generate-SDK-From-Json.ps1
@@ -63,22 +63,13 @@ try
         }
     }
 
-    # Process the SIS Vendor Profile
-    #foreach( $entry in $response) 
-    #{
-    #    if ( $entry.name -eq "Minnesota-Preview-SISVendor-Profile" )
-    #    {
-    #        # Create Minnesota SIS Vendor Profile 
-    #        # (Client, Apis.Profiles.Minnesota_Preview_SISVendor_Profile and Models.Profiles.Minnesota_Preview_SISVendor_Profile)
-    #        & $javaExecutable $params -i $entry.endpointUri --api-package Apis.Profiles.Minnesota_Preview_SISVendor_Profile  --model-package Models.Profiles.Minnesota_Preview_SISVendor_Profile
-    #    }
-    #}
-
     # Process the Minnesota Profile(s)
+    # The upcoming school year profile needs to be created last so that ApiClient.cs uses the correct profile. 
     foreach( $entry in $response) 
     {
-        if ( $entry.name -like "Minnesota-*-SIS-Vendor-Profile" )
+        if ( $entry.name -like "Minnesota-*-SIS-Vendor-Profile" -And $entry.name -like "*Twenty-Five-Twenty-Six*" )
         {
+            
             # Create the Profile
             # (Client, Apis.Profiles.Minnesota- ... -SISVendor-Profile, Models.Minnesota- ... -SISVendor-Profile)  
             $namespace = $entry.name.Replace("-", "_").Replace("SIS_Vendor", "SISVendor")

--- a/MDE-EdFiClientSDK/EdFi/OdsApiv62_2026/src/EdFi.OdsApi.Sdk/Client/ApiClient.cs
+++ b/MDE-EdFiClientSDK/EdFi/OdsApiv62_2026/src/EdFi.OdsApi.Sdk/Client/ApiClient.cs
@@ -71,10 +71,10 @@ namespace EdFi.OdsApi.Sdk.Client
         /// <returns>A JSON string.</returns>
         public string Serialize(object obj)
         {
-            if (obj != null && obj is EdFi.OdsApi.Sdk.Models.Profiles.Minnesota_Twenty_Four_Twenty_Five_SISVendor_Profile.AbstractOpenAPISchema)
+            if (obj != null && obj is EdFi.OdsApi.Sdk.Models.Profiles.Minnesota_Twenty_Five_Twenty_Six_SISVendor_Profile.AbstractOpenAPISchema)
             {
                 // the object to be serialized is an oneOf/anyOf schema
-                return ((EdFi.OdsApi.Sdk.Models.Profiles.Minnesota_Twenty_Four_Twenty_Five_SISVendor_Profile.AbstractOpenAPISchema)obj).ToJson();
+                return ((EdFi.OdsApi.Sdk.Models.Profiles.Minnesota_Twenty_Five_Twenty_Six_SISVendor_Profile.AbstractOpenAPISchema)obj).ToJson();
             }
             else
             {
@@ -497,11 +497,11 @@ namespace EdFi.OdsApi.Sdk.Client
             }
 
             // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
-            if (typeof(EdFi.OdsApi.Sdk.Models.Profiles.Minnesota_Twenty_Four_Twenty_Five_SISVendor_Profile.AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
+            if (typeof(EdFi.OdsApi.Sdk.Models.Profiles.Minnesota_Twenty_Five_Twenty_Six_SISVendor_Profile.AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
             {
                 try
                 {
-                    response.Data = (T) typeof(T).GetMethod("FromJson").Invoke(null, new object[] { response.Content });
+                    response.Data = (T)typeof(T).GetMethod("FromJson").Invoke(null, new object[] { response.Content });
                 }
                 catch (Exception ex)
                 {
@@ -621,9 +621,9 @@ namespace EdFi.OdsApi.Sdk.Client
             }
 
             // if the response type is oneOf/anyOf, call FromJSON to deserialize the data
-            if (typeof(EdFi.OdsApi.Sdk.Models.Profiles.Minnesota_Twenty_Four_Twenty_Five_SISVendor_Profile.AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
+            if (typeof(EdFi.OdsApi.Sdk.Models.Profiles.Minnesota_Twenty_Five_Twenty_Six_SISVendor_Profile.AbstractOpenAPISchema).IsAssignableFrom(typeof(T)))
             {
-                response.Data = (T) typeof(T).GetMethod("FromJson").Invoke(null, new object[] { response.Content });
+                response.Data = (T)typeof(T).GetMethod("FromJson").Invoke(null, new object[] { response.Content });
             }
             else if (typeof(T).Name == "Stream") // for binary response
             {


### PR DESCRIPTION
The metadata contained both the 2025 and 2026 school years. When the profiles were compiled, the 2024-2025 was executed last so the the ApiClient.cs contained references to that profile. This fix change it so that the upcoming school year will be the only one executed. This will get the ApiClient.cs to have the correct profile.